### PR TITLE
Add ability to sync Plex Ratings to MediaMonkey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ wheels/
 *.manifest
 *.spec
 
-# Installer logs
+# Logs
+sync_ratings.log
 pip-log.txt
 pip-delete-this-directory.txt
 
@@ -69,6 +70,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+.ipynb
 
 # pyenv
 .python-version

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,7 @@ wheels/
 *.manifest
 *.spec
 
-# Logs
-sync_ratings.log
+# Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
 

--- a/MediaPlayer.py
+++ b/MediaPlayer.py
@@ -48,6 +48,7 @@ class MediaPlayer(abc.ABC):
 		return normed_rating * self.rating_maximum
 
 	def get_normed_rating(self, rating):
+		if rating <0: rating = 0
 		return rating / self.rating_maximum
 
 	@abc.abstractmethod
@@ -152,10 +153,7 @@ class MediaMonkey(MediaPlayer):
 
 	def read_track_metadata(self, track):
 		tag = AudioTag(track.Artist.Name, track.Album.Name, track.Title)
-		if track.Rating <0: 
-			tag.rating=0
-		else:
-			tag.rating = self.get_normed_rating(track.Rating)
+		tag.rating = self.get_normed_rating(track.Rating)
 		tag.ID = track.ID
 		return tag
 

--- a/MediaPlayer.py
+++ b/MediaPlayer.py
@@ -185,6 +185,7 @@ class MediaMonkey(MediaPlayer):
 		if not self.dry_run: 
 			song = self.sdb.Database.QuerySongs('ID='+str(track.ID))
 			song.Item.Rating = self.get_native_rating(rating)
+			song.Item.UpdateDB()
 
 class PlexPlayer(MediaPlayer):
 #TODO logging needs to be updated to reflect whether Plex is source or destination

--- a/MediaPlayer.py
+++ b/MediaPlayer.py
@@ -170,8 +170,9 @@ class MediaMonkey(MediaPlayer):
 			tags.append(self.read_track_metadata(it.Item))
 			counter += 1
 			it.Next()
-
-		self.logger.info('Read {} tracks with a rating > 0'.format(counter))
+			
+		if "rating" in query:
+			self.logger.info('Read {} tracks with a rating > 0'.format(counter))
 		return tags
 
 	def update_playlist(self, playlist, track, present):
@@ -181,7 +182,9 @@ class MediaMonkey(MediaPlayer):
 		self.logger.debug('Updating rating of track "{}" to {} stars'.format(
 			format_mediamonkey_track(track), self.get_5star_rating(rating))
 		)
-		if not self.dry_run: self.sdb.Database.QuerySongs('ID='+str(track.ID)).Item.Rating=self.get_native_rating(rating)
+		if not self.dry_run: 
+			song = self.sdb.Database.QuerySongs('ID='+str(track.ID))
+			song.Item.Rating = self.get_native_rating(rating)
 
 class PlexPlayer(MediaPlayer):
 #TODO logging needs to be updated to reflect whether Plex is source or destination

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project aims to provide a simple sync tool that synchronizes the track rati
 * [MediaMonkey](http://www.mediamonkey.com/) v4.0 or higher
 *  _Plex Media Server_ (PMS)
 * Python 3.6 or higher with packages:
-    * [PlexAPI v3.0.6](https://pypi.org/project/PlexAPI/)
+    * [PlexAPI v4.2.0](https://pypi.org/project/PlexAPI/)
     * [pypiwin32](https://pypi.org/project/pypiwin32/): to use the COM interface
     * [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy): for fuzzy string matching
     * [python-Levenshtein](https://github.com/miohtama/python-Levenshtein) (optional): to improve performance of `fuzzywuzzy`
@@ -56,6 +56,7 @@ Using the `--dry` flag in combination with `--log DEBUG` is recommended to see w
 
 ## Current issues
 * the [PlexAPI](https://pypi.org/project/PlexAPI/) seems to be only working for the administrator of the PMS.
+* playlist synchronization from Plex to local player not implemented
 
 ## Potential next features
 With the current state I have completed all functionality I desired to have.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project aims to provide a simple sync tool that synchronizes the track rati
 The main file is `sync_ratings.py`.
 Usage description:
 ```
-usage: sync_ratings.py [-h] [--dry] [--log LOG] [--passwd PASSWD] 
+usage: sync_ratings.py [-h] [--dry] [--reverse] [--log LOG] [--passwd PASSWD] 
                        [--player PLAYER] --server SERVER --username USERNAME
 
 Synchronizes ID3 music ratings with a Plex media-server
@@ -43,6 +43,7 @@ Synchronizes ID3 music ratings with a Plex media-server
 optional arguments:
   -h, --help           show this help message and exit
   --dry                Does not apply any changes
+  --reverse            Reverses ratings synchronization from Plex to local player
   --log LOG            Sets the logging level
   --passwd PASSWD      The password for the plex user. NOT RECOMMENDED TO USE!
   --player PLAYER      Media player to synchronize with Plex [default is MediaMonkey]

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This project aims to provide a simple sync tool that synchronizes the track rati
 The main file is `sync_ratings.py`.
 Usage description:
 ```
-usage: sync_ratings.py [-h] [--dry] [--log LOG] [--passwd PASSWD] --player
-                       PLAYER --server SERVER --username USERNAME
+usage: sync_ratings.py [-h] [--dry] [--log LOG] [--passwd PASSWD] 
+                       [--player PLAYER] --server SERVER --username USERNAME
 
 Synchronizes ID3 music ratings with a Plex media-server
 
@@ -45,12 +45,12 @@ optional arguments:
   --dry                Does not apply any changes
   --log LOG            Sets the logging level
   --passwd PASSWD      The password for the plex user. NOT RECOMMENDED TO USE!
-  --player PLAYER      Media player to synchronize with Plex
+  --player PLAYER      Media player to synchronize with Plex [default is MediaMonkey]
   --server SERVER      The name of the plex media server
   --username USERNAME  The plex username
 ```
 Start the synchronization:
-`./sync_ratings.py --server <server_name> --username <my@email.com|user_name> --player MediaMonkey`
+`./sync_ratings.py --server <server_name> --username <my@email.com|user_name>`
 Using the `--dry` flag in combination with `--log DEBUG` is recommended to see what changes will be made.
 
 ## Current issues

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PlexAPI>=3.0.6
+PlexAPI>=4.2.0
 fuzzywuzzy
 pypiwin32
 numpy

--- a/sync_items.py
+++ b/sync_items.py
@@ -35,3 +35,4 @@ class Playlist(object):
 
 	def __str__(self):
 		return '{}: {} tracks'.format(self.name, self.num_tracks)
+

--- a/sync_pair.py
+++ b/sync_pair.py
@@ -173,7 +173,7 @@ class TrackPair(SyncPair):
 
 	def sync(self):
 		#change everything to source/destination
-		if self.rating_source == 0.0:
+		if self.rating_destination <= 0.0:
 			# Propagate the rating of the remote track to the local track
 			self.destination_player.update_rating(self.destination, self.rating_source)
 		else:

--- a/sync_pair.py
+++ b/sync_pair.py
@@ -134,9 +134,9 @@ class TrackPair(SyncPair):
 
 		self.rating_source = self.source.rating
 		if self.destination_player.name()=="PlexPlayer": 
-			self.rating_destination = self.destination_player.get_normed_rating(float(self.destination.userRating)) 				if 'userRating' in self.destination.userRating 				else 0
+			self.rating_destination = self.destination.userRating
 		else:
-			self.rating_destination = self.destination_player.get_normed_rating(float(self.destination.rating))
+			self.rating_destination = self.destination.rating
 
 		if self.rating_source == self.rating_destination:
 			self.sync_state = SyncState.UP_TO_DATE
@@ -144,8 +144,8 @@ class TrackPair(SyncPair):
 			self.sync_state = SyncState.NEEDS_UPDATE
 		elif self.rating_source != self.rating_destination:
 			self.sync_state = SyncState.CONFLICTING
-			self.logger.warning('Found match with conflicting ratings: {}'.format(
-				self.source)
+			self.logger.warning('Found match with conflicting ratings: {} (Source: {} | Destination; {})'.format(
+				self.source, self.rating_source, self.rating_destination)
 			)
 
 		return score

--- a/sync_pair.py
+++ b/sync_pair.py
@@ -154,7 +154,6 @@ class TrackPair(SyncPair):
 		return NotImplemented
 
 	def similarity(self, candidate):
-        ########################i'm here
 		"""
 		Determines the matching similarity of @candidate with the source query track
 		:type candidate: Track

--- a/sync_pair.py
+++ b/sync_pair.py
@@ -19,21 +19,22 @@ class SyncState(Enum):
 
 
 class SyncPair(abc.ABC):
-	local = None
-	remote = None
+	source = None
+	destination = None
 	sync_state = SyncState.UNKNOWN
 
-	def __init__(self, local_player, remote_player):
-		"""
-		:type local_player: MediaPlayer.MediaPlayer
-		:type remote_player: MediaPlayer.PlexPlayer
-		"""
-		self.local_player = local_player
-		self.remote_player = remote_player
+	def __init__(self, source_player, destination_player):
+		#"""
+		#TODO: this is no longer true - not sure if it matters
+		#:type local_player: MediaPlayer.MediaPlayer
+		#:type remote_player: MediaPlayer.PlexPlayer
+		#"""
+		self.source_player = source_player
+		self.destination_player = destination_player
 
 	@abc.abstractmethod
 	def match(self):
-		"""Tries to find a match on the remote player that matches the local replica as good as possible"""
+		"""Tries to find a match on the destination player that matches the source replica as good as possible"""
 
 	@abc.abstractmethod
 	def resolve_conflict(self):
@@ -41,58 +42,74 @@ class SyncPair(abc.ABC):
 
 	@abc.abstractmethod
 	def similarity(self, candidate):
-		"""Determines the similarity of the local replica with the candidate replica"""
+		"""Determines the similarity of the source replica with the candidate replica"""
 
 	@abc.abstractmethod
 	def sync(self):
 		"""
-		Synchronizes the local and remote replicas
+		Synchronizes the source and destination replicas
 		:return flag indicating success
 		:rtype: bool
 		"""
 
-
 class TrackPair(SyncPair):
-	rating_local = 0.0
-	rating_remote = 0.0
+	rating_source = 0.0
+	rating_destination = 0.0
 
-	def __init__(self, local_player, remote_player, local_track):
-		"""
-		:type local_player: MediaPlayer.MediaPlayer
-		:type remote_player: MediaPlayer.PlexPlayer
-		:type local_track: AudioTag
-		"""
-		super(TrackPair, self).__init__(local_player, remote_player)
+	def __init__(self, source_player, destination_player, source_track):
+		#"""
+		#TODO: this is no longer true - not sure if it matters
+		#:type local_player: MediaPlayer.MediaPlayer
+		#:type remote_player: MediaPlayer.PlexPlayer
+		#"""
+		super(TrackPair, self).__init__(source_player, destination_player)
 		self.logger = logging.getLogger('PlexSync.TrackPair')
-		self.local = local_track
+		self.source = source_track
 
-	def albums_similarity(self, remote=None):
+	def albums_similarity(self, destination=None):
 		"""
 		Determines how similar two album names are. It takes into account different conventions for empty album names.
-
-		:type remote: str
-			 optional album title to compare the album name of the local track with
+		:type destination: str
+			 optional album title to compare the album name of the source track with
 		:returns a similarity rating [0, 100]
 		:rtype: int
 		"""
-		if remote is None:
-			remote = self.remote
-		if self.both_albums_empty(remote=remote):
+		if destination is None:
+			destination = self.destination
+		if self.both_albums_empty(destination=destination):
 			return 100
 		else:
-			return fuzz.ratio(self.local.album, remote.album().title)
+			if self.destination_player.name()=="PlexPlayer":            
+				return fuzz.ratio(self.source.album, destination.album().title)
+			else:
+				return fuzz.ratio(self.source.album, destination.album)
 
-	def both_albums_empty(self, remote=None):
-		if remote is None: remote = self.remote
-		return self.local_player.album_empty(self.local.album) and self.remote_player.album_empty(remote.album().title)
+	def both_albums_empty(self, destination=None):
+		if destination is None: destination = self.destination
+		if self.destination_player.name()=="PlexPlayer":   
+			return self.source_player.album_empty(self.source.album) and self.destination_player.album_empty(destination.album().title)
+		else:
+			return self.source_player.album_empty(self.source.album) and self.destination_player.album_empty(destination.album)
 
 	def match(self, candidates=None, match_threshold=30):
-		if self.local is None: raise RuntimeError('Local track not set')
+		if self.source is None: raise RuntimeError('Source track not set')
 		if candidates is None:
-			candidates = self.remote_player.search_tracks(title=self.local.title)
+			if self.destination_player.name()=="PlexPlayer":  
+				candidates = self.destination_player.search_tracks(title=self.source.title)
+			else:
+				title=self.source.title
+				if "\"" in title:
+					part_len=0
+					title_parts = title.split("\"")
+					for index,part in enumerate(title_parts):
+						if len(part) > part_len: 
+							part_len = len(part)
+							long_part=index
+					title=title_parts[long_part]
+				candidates = self.destination_player.search_tracks(query="SongTitle like \"%"+ title +"%\"")
 		if len(candidates) == 0:
 			self.sync_state = SyncState.ERROR
-			self.logger.warning('No match found for {}'.format(self.local))
+			self.logger.warning('No match found for {}'.format(self.source))
 			return 0
 		scores = np.array([self.similarity(candidate) for candidate in candidates])
 		ranks = scores.argsort()
@@ -104,23 +121,32 @@ class TrackPair(SyncPair):
 			))
 			return score
 
-		self.remote = candidates[ranks[-1]]
-		self.logger.debug('Found match with score {} for {}: {}'.format(
-			score, self.local, format_plexapi_track(self.remote)
-		))
+		self.destination = candidates[ranks[-1]]
+		if self.destination_player.name()=="PlexPlayer": 
+			self.logger.debug('Found match with score {} for {}: {}'.format(
+				score, self.source, format_plexapi_track(self.destination)
+			))
+		else:
+			#TODO: this needs generized to handle multiple local players
+			self.logger.debug('Found match with score {} for {}: {}'.format(
+				score, self.source, format_mediamonkey_track(self.destination)
+			))
 
-		self.rating_local = self.local.rating
-		# TODO: use public accessor method, once PR-263 gets merged: https://github.com/pkkid/python-plexapi/pull/263
-		self.rating_remote = self.remote_player.get_normed_rating(float(self.remote._data.attrib['userRating'])) \
-			if 'userRating' in self.remote._data.attrib \
-			else 0
+		self.rating_source = self.source.rating
+		if self.destination_player.name()=="PlexPlayer": 
+			self.rating_destination = self.destination_player.get_normed_rating(float(self.destination.userRating)) 				if 'userRating' in self.destination.userRating 				else 0
+		else:
+			self.rating_destination = self.destination_player.get_normed_rating(float(self.destination.rating))
 
-		if self.rating_local == self.rating_remote:
+		if self.rating_source == self.rating_destination:
 			self.sync_state = SyncState.UP_TO_DATE
-		elif self.rating_local == 0.0 or self.rating_remote == 0.0:
+		elif self.rating_source == 0.0 or self.rating_destination == 0.0:
 			self.sync_state = SyncState.NEEDS_UPDATE
-		elif self.rating_local != self.rating_remote:
+		elif self.rating_source != self.rating_destination:
 			self.sync_state = SyncState.CONFLICTING
+			self.logger.warning('Found match with conflicting ratings: {}'.format(
+				self.source)
+			)
 
 		return score
 
@@ -128,30 +154,35 @@ class TrackPair(SyncPair):
 		return NotImplemented
 
 	def similarity(self, candidate):
+        ########################i'm here
 		"""
-		Determines the matching similarity of @candidate with the local query track
+		Determines the matching similarity of @candidate with the source query track
 		:type candidate: Track
 		:returns a similarity rating [0.0, 100.0]
 		:rtype: float
 		"""
-		scores = np.array([fuzz.ratio(self.local.title, candidate.title),
-		                   fuzz.ratio(self.local.artist, candidate.artist().title),
-		                   self.albums_similarity(remote=candidate)])
+		if self.destination_player.name()=="PlexPlayer": 
+			scores = np.array([fuzz.ratio(self.source.title, candidate.title),
+			                   fuzz.ratio(self.source.artist, candidate.artist().title),
+			                   self.albums_similarity(destination=candidate)])
+		else:
+			scores = np.array([fuzz.ratio(self.source.title, candidate.title),
+			                   fuzz.ratio(self.source.artist, candidate.artist),
+			                   self.albums_similarity(destination=candidate)])  
 		return np.average(scores)
 
 	def sync(self):
-		if self.rating_local == 0.0:
+		#change everything to source/destination
+		if self.rating_source == 0.0:
 			# Propagate the rating of the remote track to the local track
-			self.local_player.update_rating(self.local, self.rating_remote)
-		elif self.rating_remote == 0.0:
-			# Propagate the rating of the local track to the remote track
-			self.remote_player.update_rating(self.remote, self.rating_local)
+			self.destination_player.update_rating(self.destination, self.rating_source)
 		else:
 			return False
 		return True
 
 
 class PlaylistPair(SyncPair):
+	#TODO: finish implementing playlist sync for MediaMonkey -> Plexfo
 	remote: [Playlist]
 
 	def __init__(self, local_player, remote_player, local_playlist):
@@ -199,3 +230,4 @@ class PlaylistPair(SyncPair):
 					self.remote_player.update_playlist(self.remote, pair.remote, True)
 
 		return True
+

--- a/sync_ratings.py
+++ b/sync_ratings.py
@@ -103,9 +103,11 @@ class PlexSync:
 	def sync_tracks(self):
 		if self.options.reverse:
 			tracks = self.remote_player.search_tracks(rating=True)
+			self.logger.info('Attempting to match {} tracks'.format(len(tracks)))
 			sync_pairs = [TrackPair(self.remote_player, self.local_player, track) for track in tracks]
 		else:
 			tracks = self.local_player.search_tracks(query='Rating > 0')
+			self.logger.info('Attempting to match {} tracks'.format(len(tracks)))
 			sync_pairs = [TrackPair(self.local_player, self.remote_player, track) for track in tracks]
 
 		self.logger.info('Matching source tracks with destination player')

--- a/sync_ratings.py
+++ b/sync_ratings.py
@@ -152,8 +152,8 @@ def parse_args():
 	parser.add_argument('--log', default='debug', help='Sets the logging level')
 	parser.add_argument('--passwd', type=str, help='The password for the plex user. NOT RECOMMENDED TO USE!')
 	parser.add_argument('--player', default='MediaMonkey', type=str, help='Media player to synchronize with Plex')
-	parser.add_argument('--server', required=True, type=str,  help='The name of the plex media server')
-	parser.add_argument('--username', required=True, type=str, help='The plex username')
+	parser.add_argument('--server', type=str, required=True, help='The name of the plex media server')
+	parser.add_argument('--username', type=str, required=True, help='The plex username')
 
 	return parser.parse_args()
 

--- a/sync_ratings.py
+++ b/sync_ratings.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import locale
 import logging

--- a/sync_ratings.py
+++ b/sync_ratings.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 import locale
 import logging
@@ -13,7 +11,6 @@ class InfoFilter(logging.Filter):
 	def filter(self, rec):
 		return rec.levelno in (logging.DEBUG, logging.INFO)
 
-
 class PlexSync:
 	log_levels = {
 		'CRITICAL': logging.CRITICAL,
@@ -23,13 +20,14 @@ class PlexSync:
 		'DEBUG': logging.DEBUG
 	}
 
-	def __init__(self, options):
+	def __init__(self, options):   
 		self.logger = logging.getLogger('PlexSync')
 		self.options = options
 		self.setup_logging()
 		self.local_player = self.get_player()
 		self.remote_player = PlexPlayer()
 		self.local_player.dry_run = self.remote_player.dry_run = self.options.dry
+		self.local_player.reverse = self.remote_player.reverse = self.options.reverse
 
 	def get_player(self):
 		"""
@@ -98,13 +96,19 @@ class PlexSync:
 			password=self.options.passwd,
 		)
 		self.sync_tracks()
-		self.sync_playlists()
-
+		#TODO: finish implementing playlist sync for MediaMonkey -> Plex
+		if not self.options.reverse:
+			self.sync_playlists()
+        
 	def sync_tracks(self):
-		tracks = self.local_player.search_tracks(query='Rating > 0')
-		sync_pairs = [TrackPair(self.local_player, self.remote_player, track) for track in tracks]
+		if self.options.reverse:
+			tracks = self.remote_player.search_tracks(rating=True)
+			sync_pairs = [TrackPair(self.remote_player, self.local_player, track) for track in tracks]
+		else:
+			tracks = self.local_player.search_tracks(query='Rating > 0')
+			sync_pairs = [TrackPair(self.local_player, self.remote_player, track) for track in tracks]
 
-		self.logger.info('Matching local tracks with remote player')
+		self.logger.info('Matching source tracks with destination player')
 		matched = 0
 		for pair in sync_pairs:
 			if pair.match(): matched += 1
@@ -122,6 +126,8 @@ class PlexSync:
 			pair.resolve_conflict()
 
 	def sync_playlists(self):
+		if self.options.reverse:
+			raise NotImplementedError
 		playlists = self.local_player.read_playlists()
 		playlist_pairs = [PlaylistPair(self.local_player, self.remote_player, pl)
 		                  for pl in playlists if not pl.is_auto_playlist]
@@ -140,12 +146,17 @@ class PlexSync:
 def parse_args():
 	parser = argparse.ArgumentParser(description='Synchronizes ID3 music ratings with a Plex media-server')
 	parser.add_argument('--dry', action='store_true', help='Does not apply any changes')
-	parser.add_argument('--log', default='info', help='Sets the logging level')
+	parser.add_argument('--reverse', action='store_true', help='Syncs ratings from Plex to local player')
+	parser.add_argument('--log', default='debug', help='Sets the logging level')
 	parser.add_argument('--passwd', type=str, help='The password for the plex user. NOT RECOMMENDED TO USE!')
-	parser.add_argument('--player', type=str, required=True, help='Media player to synchronize with Plex')
-	parser.add_argument('--server', type=str, required=True, help='The name of the plex media server')
-	parser.add_argument('--username', type=str, required=True, help='The plex username')
+	parser.add_argument('--player', default='MediaMonkey', type=str, help='Media player to synchronize with Plex')
+	parser.add_argument('--server', default='media',type=str,  help='The name of the plex media server')
+	parser.add_argument('--username', default='smilerz',type=str, help='The plex username')
+	#parser.add_argument('--player', default='MediaMonkey', type=str, required=True, help='Media player to synchronize with Plex')
+	#parser.add_argument('--server', default='media',type=str, required=True, help='The name of the plex media server')
+	#parser.add_argument('--username', default='smilerz',type=str, required=True, help='The plex username')
 	return parser.parse_args()
+
 
 
 if __name__ == "__main__":

--- a/sync_ratings.py
+++ b/sync_ratings.py
@@ -150,11 +150,9 @@ def parse_args():
 	parser.add_argument('--log', default='debug', help='Sets the logging level')
 	parser.add_argument('--passwd', type=str, help='The password for the plex user. NOT RECOMMENDED TO USE!')
 	parser.add_argument('--player', default='MediaMonkey', type=str, help='Media player to synchronize with Plex')
-	parser.add_argument('--server', default='media',type=str,  help='The name of the plex media server')
-	parser.add_argument('--username', default='smilerz',type=str, help='The plex username')
-	#parser.add_argument('--player', default='MediaMonkey', type=str, required=True, help='Media player to synchronize with Plex')
-	#parser.add_argument('--server', default='media',type=str, required=True, help='The name of the plex media server')
-	#parser.add_argument('--username', default='smilerz',type=str, required=True, help='The plex username')
+	parser.add_argument('--server', required=True, type=str,  help='The name of the plex media server')
+	parser.add_argument('--username', required=True, type=str, help='The plex username')
+
 	return parser.parse_args()
 
 

--- a/utils.py
+++ b/utils.py
@@ -4,3 +4,7 @@ This file contains helper functions
 
 def format_plexapi_track(track):
 	return ' - '.join([track.artist().title, track.album().title, track.title])
+
+def format_mediamonkey_track(track):
+    #TODO: this needs generized to handle multiple local players
+	return ' - '.join([track.artist, track.album, track.title])


### PR DESCRIPTION
-command line flag added to reverse direction of sync
-resolved this # TODO: use public accessor method, once PR-263 gets merged: https://github.com/pkkid/python-plexapi/pull/263
-fixes #7, bug causing false positives on rating mismatch